### PR TITLE
:arrow_heading_down: Merge from upstream to fix aggressive AWS secret matcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sanctify (0.2.4)
+    sanctify (0.2.5)
       git (~> 1.3)
 
 GEM
@@ -40,4 +40,4 @@ DEPENDENCIES
   sanctify!
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/sanctify/cli.rb
+++ b/lib/sanctify/cli.rb
@@ -42,6 +42,7 @@ module Sanctify
         end
       end
       Scanner.new(args).run
+      puts "SUCCESS! No Secrets Found in #{args[:repo]}"
     end
   end
 end

--- a/lib/sanctify/matcher_list.rb
+++ b/lib/sanctify/matcher_list.rb
@@ -29,7 +29,7 @@ module Sanctify
       },
       {
         description: "AWS Secret Key",
-        regex: /\b(?<![A-Za-z0-9\/+=])(?=.*[\/&?=-@#$%\\^+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])\b/
+        regex: /\b(?<![A-Za-z0-9\/+=])(?=.*[&?=-@#$%\\^+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])\b/
       },
       {
         description: "SSH RSA Private Key",

--- a/lib/sanctify/scanner.rb
+++ b/lib/sanctify/scanner.rb
@@ -20,7 +20,6 @@ module Sanctify
           end
         end
       end
-      puts "SUCCESS! No Secrets Found in #{repo.path}"
     end
 
     private

--- a/spec/lib/scanner_spec.rb
+++ b/spec/lib/scanner_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe Sanctify::Scanner, git: true do
       end
     end
 
+    context 'with AWS Secret Key that does not have a "/" character' do
+      let(:payload) { "pIW+g216XEHyoF+dIHkYgh439nGko8ga65VTusGF" }
+      it 'raises an error' do
+        expect{ subject }.to raise_error(Sanctify::ScannerError)
+      end
+    end
+
+    context 'with an innocent 40-character path using a base64 alphabet' do
+      let(:payload) { "yourlibrary/some/40/character/path/Thing" }
+      it 'does not raise an error' do
+        expect{ subject }.not_to raise_error
+      end
+    end
+
+    context 'with a 40-character string using a base64 alphabet' do
+      let(:payload) { "OKIKnowSomeClassNamesAreJustReallyLongOK" }
+      it 'does not raise an error' do
+        expect{ subject }.not_to raise_error
+      end
+    end
+
     context 'with git sha' do
       let(:payload) { "a74e98e6c224a9d2dba20c858009a4cb51689822" }
       it 'does not raise an error' do


### PR DESCRIPTION
Identical to #1 but with merge commit from upstream.